### PR TITLE
feat(repo): Adding eslint rules for modules boundaries

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,21 +5,67 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {
-        "@nrwl/nx/enforce-module-boundaries": [
-          "error",
-          {
-            "enforceBuildableLibDependency": true,
-            "allow": [],
-            "depConstraints": [
-              {
-                "sourceTag": "*",
-                "onlyDependOnLibsWithTags": ["*"]
-              }
-            ]
-          }
-        ]
-      }
+        "rules": {
+          "@nrwl/nx/enforce-module-boundaries": [
+            "error",
+            {
+              "allow": [],
+              "depConstraints": [
+                // projects without any tags will be able to depend on any other project
+                {
+                  "sourceTag": "*",
+                  "onlyDependOnLibsWithTags": ["*"]
+                },
+                {
+                  "sourceTag": "scope:shared",
+                  "onlyDependOnLibsWithTags": ["scope:shared"]
+                },
+                {
+                  "sourceTag": "scope:angular-app-a",
+                  "onlyDependOnLibsWithTags": ["scope:shared", "scope:angular-app-a"]
+                },
+                {
+                  "sourceTag": "scope:react-app-a",
+                  "onlyDependOnLibsWithTags": ["scope:shared", "scope:react-app-a"]
+                },
+                {
+                  "sourceTag": "scope:portal",
+                  "onlyDependOnLibsWithTags": ["scope:shared", "scope:portal"]
+                },
+                {
+                  "sourceTag": "scope:nest-backend",
+                  "onlyDependOnLibsWithTags": ["scope:shared", "scope:nest-backend"]
+                },      
+                {
+                  "sourceTag": "type:app",
+                  "onlyDependOnLibsWithTags": [
+                    "type:feature",
+                    "type:ui",
+                    "type:util",
+                    "type:data-access"
+                  ]
+                },
+                {
+                  "sourceTag": "type:feature",
+                  "onlyDependOnLibsWithTags": [
+                    "type:data-access",
+                    "type:feature",
+                    "type:ui",
+                    "type:util"
+                  ]
+                },
+                {
+                  "sourceTag": "type:ui",
+                  "onlyDependOnLibsWithTags": ["type:ui", "type:util"]
+                },
+                {
+                  "sourceTag": "type:util",
+                  "onlyDependOnLibsWithTags": ["type:util"]
+                }
+              ]
+            }
+          ]
+        }
     },
     {
       "files": ["*.ts", "*.tsx"],


### PR DESCRIPTION
Adding initial modules boundaries rules.
A scope should only be able to depend on its own scope and a shared one. Defining rules about libraries types, app, feature, ui, util and how they are allowed to interact.

Signed-off-by: Laboiite <>